### PR TITLE
Use correct format strings

### DIFF
--- a/status_test.go
+++ b/status_test.go
@@ -93,7 +93,7 @@ func TestServeStatusValidCodes(t *testing.T) {
 					t.Fatalf("request to /%03d returned status code %03d, expected %03d", tc.code, res.StatusCode, tc.code)
 				}
 				if res.Header.Get("x-status-code") != strconv.Itoa(tc.code) {
-					t.Fatalf("request to /%03d returned x-status-code header %03d, expected %03d", tc.code, res.Header.Get("x-status-code"), tc.code)
+					t.Fatalf("request to /%03d returned x-status-code header %s, expected %03d", tc.code, res.Header.Get("x-status-code"), tc.code)
 				}
 				if res.Header.Get("x-status") != http.StatusText(tc.code) {
 					t.Fatalf("request to /%03d returned x-status header %q, expected %q", tc.code, res.Header.Get("x-status"), http.StatusText(tc.code))
@@ -171,7 +171,7 @@ func TestServeStatusUnsupportedCodes(t *testing.T) {
 					t.Fatalf("request to /%03d returned status code %03d, expected %03d", tc.code, res.StatusCode, http.StatusNotFound)
 				}
 				if res.Header.Get("x-status-code") != "" {
-					t.Fatalf("request to /%03d returned x-status-code header %03d, expected %03d", tc.code, res.Header.Get("x-status-code"), "")
+					t.Fatalf("request to /%03d returned x-status-code header %s, expected %03d", tc.code, res.Header.Get("x-status-code"), "")
 				}
 				if res.Header.Get("x-status") != "" {
 					t.Fatalf("request to /%03d returned x-status header %q, expected %q", tc.code, res.Header.Get("x-status"), "")
@@ -224,7 +224,7 @@ func TestServeStatusNotCodes(t *testing.T) {
 					t.Fatalf("request to %q returned status code %03d, expected %03d", tc.path, res.StatusCode, http.StatusNotFound)
 				}
 				if res.Header.Get("x-status-code") != "" {
-					t.Fatalf("request to /%q returned x-status-code header %03d, expected %03d", tc.path, res.Header.Get("x-status-code"), "")
+					t.Fatalf("request to /%q returned x-status-code header %s, expected %03d", tc.path, res.Header.Get("x-status-code"), "")
 				}
 				if res.Header.Get("x-status") != "" {
 					t.Fatalf("request to /%q returned x-status header %q, expected %q", tc.path, res.Header.Get("x-status"), "")


### PR DESCRIPTION
Instead of using the decimal format string, use the string format string.