### PR TITLE
Replace the static worker pool with a limit

### DIFF
--- a/pace.go
+++ b/pace.go
@@ -12,7 +12,7 @@ import (
 func Pace(count int, work http.Handler) http.Handler {
 	sem := make(chan struct{}, count)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sem <- struct{}
+		sem <- struct{}{}
 		defer func(){
 			<-sem
 		}()


### PR DESCRIPTION
Instead of created a static pool of workers, use a semaphore to
ensure that the total number of active workers is limited. This
could be expanded to include a timeout, but the semaphore is
enough for now. It would be worth it to benchmark the performance
of the semaphore version against the previous version. I wonder
what circumstance might make the pipeline version a better choice.